### PR TITLE
fix hanging when failing

### DIFF
--- a/holocure_fishing.py
+++ b/holocure_fishing.py
@@ -173,39 +173,25 @@ def fishing():
                     print(f"region: {region}")
                 debug_screenshot(pyautogui.screenshot(region=pre_region), title="scanbox")
                 debug_screenshot(pyautogui.screenshot(region=region), title="hitbox")
-        else:
+        elif retry > 0:
             # we found a running hit area
             
+            retry -= 1
             if not prepared:
-                retry -= 1
-                if retry < 1:
-                    # we did not find any needle within max_retry
-                    retry = max_retry
-                    # check if hit area is still present to continue minigame
-                    hit_area = pyautogui.locateOnScreen(f"{dir_path}/img/{res}/box.png", grayscale=True, region=region, confidence=0.6)
-                    # when hit_area turns None, we assume we missed the end of the minigame and return to search for the OK
-                else:
-                    # take a picture of the area before the hit area
-                    pic = pyautogui.screenshot(region=pre_region)
-                    # try to find a needle in advance
-                    for needle in needles.items():
-                        if pyautogui.locate(f"{dir_path}/img/{res}/{needle[0]}.png", pic, grayscale=True, confidence=0.8) is not None:
-                            print(f"prepare {needle[0]}")
-                            debug_screenshot(pic,title=f"prepare_{needle[0]}")
-                            prepared = needle
-                            retry = max_retry
-                            break
-                    if not prepared:
-                        # we did not find any needles
-                        debug_screenshot(pic,title=f"scanning_{needle[0]}")
+                # take a picture of the area before the hit area
+                pic = pyautogui.screenshot(region=pre_region)
+                # try to find a needle in advance
+                for needle in needles.items():
+                    if pyautogui.locate(f"{dir_path}/img/{res}/{needle[0]}.png", pic, grayscale=True, confidence=0.8) is not None:
+                        print(f"prepare {needle[0]}")
+                        debug_screenshot(pic,title=f"prepare_{needle[0]}")
+                        prepared = needle
+                        retry = max_retry
+                        break
+                if not prepared:
+                    # we did not find any needles
+                    debug_screenshot(pic,title=f"scanning_{needle[0]}")
             else:
-                retry -= 1
-                if retry < 1:
-                    # we did not find any needle within max_retry
-                    retry = max_retry
-                    # check if hit area is still present to continue minigame
-                    hit_area = pyautogui.locateOnScreen(f"{dir_path}/img/{res}/box.png", grayscale=True, region=region, confidence=0.6)
-                    # when hit_area turns None, we assume we missed the end of the minigame and return to search for the OK
                 # take a picture of the hit area and wait for the prepared needle to arrive
                 pic = pyautogui.screenshot(region=region)
                 if pyautogui.locate(f"{dir_path}/img/{res}/{prepared[0]}.png", pic, grayscale=True, confidence=0.8) is not None:
@@ -220,6 +206,9 @@ def fishing():
                 else:
                     # needle not yet arrived
                     debug_screenshot(pic,title=f"waiting_{prepared[0]}")
+        else:
+            retry = max_retry
+            hit_area = pyautogui.locateOnScreen(f"{dir_path}/img/{res}/box.png", region=region, grayscale=True, confidence=0.6)
 
 
 try:

--- a/holocure_fishing.py
+++ b/holocure_fishing.py
@@ -193,11 +193,13 @@ def fishing():
                             print(f"prepare {needle[0]}")
                             debug_screenshot(pic,title=f"prepare_{needle[0]}")
                             prepared = needle
+                            retry = max_retry
                             break
                     if not prepared:
                         # we did not find any needles
                         debug_screenshot(pic,title=f"scanning_{needle[0]}")
             else:
+                retry -= 1
                 if retry < 1:
                     # we did not find any needle within max_retry
                     retry = max_retry

--- a/holocure_fishing.py
+++ b/holocure_fishing.py
@@ -125,6 +125,8 @@ def debug_screenshot(pic, title="screen"):
     pic.save(f"{dir_path}/debug/{i}_{title}.png")
     i += 1
 
+max_retry = 50
+
 def fishing():
     print("Welcome to Automated HoloCure Fishing!")
     print("Please open holocure, go to holo house, and start fishing!")
@@ -139,6 +141,8 @@ def fishing():
     region = None
     
     prepared = None
+    
+    retry = max_retry
     
     while True:
         # check for a hit_area inidcating a running minigame
@@ -165,22 +169,28 @@ def fishing():
                 debug_screenshot(pyautogui.screenshot(region=region), title="hitbox")
         else:
             # we found a running hit area
-            # reset press button
-            press_button = ""
             
             if not prepared:
-                # take a picture of the area before the hit area
-                pic = pyautogui.screenshot(region=pre_region)
-                # try to find a needle in advance
-                for needle in needles.items():
-                    if pyautogui.locate(f"{dir_path}/img/{res}/{needle[0]}.png", pic, confidence=0.8) is not None:
-                        print(f"prepare {needle[0]}")
-                        debug_screenshot(pic,title=f"prepare_{needle[0]}")
-                        prepared = needle
-                        break
-                if not prepared:
-                    # we did not find any needles
-                    debug_screenshot(pic,title=f"scanning_{needle[0]}")
+                retry -= 1
+                if retry < 1:
+                    # we did not find any needle within max_retry
+                    retry = max_retry
+                    # check if hit area is still present to continue minigame
+                    hit_area = pyautogui.locateOnScreen(f"{dir_path}/img/{res}/box.png", region=region, confidence=0.6)
+                    # when hit_area turns None, we assume we missed the end of the minigame and return to search for the OK
+                else:
+                    # take a picture of the area before the hit area
+                    pic = pyautogui.screenshot(region=pre_region)
+                    # try to find a needle in advance
+                    for needle in needles.items():
+                        if pyautogui.locate(f"{dir_path}/img/{res}/{needle[0]}.png", pic, confidence=0.8) is not None:
+                            print(f"prepare {needle[0]}")
+                            debug_screenshot(pic,title=f"prepare_{needle[0]}")
+                            prepared = needle
+                            break
+                    if not prepared:
+                        # we did not find any needles
+                        debug_screenshot(pic,title=f"scanning_{needle[0]}")
             else:
                 # take a picture of the hit area and wait for the prepared needle to arrive
                 pic = pyautogui.screenshot(region=region)
@@ -188,17 +198,15 @@ def fishing():
                     # needle arrived
                     print(f"pressing {prepared[0]}")
                     debug_screenshot(pic,title=f"hit_{prepared[0]}")
-                    press_button = prepared[1]
+                    press(prepared[1])
                     # reset prepared needle
                     prepared = None
+                    # check if hit area is still present to continue minigame
+                    hit_area = pyautogui.locateOnScreen(f"{dir_path}/img/{res}/box.png", region=region, confidence=0.6)
                 else:
                     # needle not yet arrived
                     debug_screenshot(pic,title=f"waiting_{prepared[0]}")
-            
-            if press_button:
-                press(press_button)
-                # check if hit area is still present to continue minigame
-                hit_area = pyautogui.locateOnScreen(f"{dir_path}/img/{res}/box.png", region=region, confidence=0.6)
+
 
 try:
     fishing()


### PR DESCRIPTION
it seems when failing there are two cases

case 1: missing the prepare scan, where we prepare for the wrong input because the pre scan region is not optimal or the scanning works to slow

case 2: after missing the hit, sometimes it seems to think the hit area is still present since the fail screen keeps the the hit area longer visible than in success

to remedy, add a retry counter to reset the statemachine